### PR TITLE
Fixes issue #2

### DIFF
--- a/cmake_project.lua
+++ b/cmake_project.lua
@@ -34,7 +34,7 @@ function m.files(prj)
 	local tr = project.getsourcetree(prj)
 	tree.traverse(tr, {
 		onleaf = function(node, depth)
-			_p(depth, '"%s"', os.getcwd(), node.abspath)
+			_p(depth, '"%s"', path.getrelative(os.getcwd(), node.abspath))
 		end
 	}, true)
 end

--- a/cmake_project.lua
+++ b/cmake_project.lua
@@ -34,7 +34,7 @@ function m.files(prj)
 	local tr = project.getsourcetree(prj)
 	tree.traverse(tr, {
 		onleaf = function(node, depth)
-			_p(depth, '"%s"', node.relpath)
+			_p(depth, '"%s"', os.getcwd(), node.abspath)
 		end
 	}, true)
 end


### PR DESCRIPTION
Fixes #2

So, this works properly in the gmake module because the make file calls make on the *.make file causing the cwd to change to the project directory. cmake include doesn't do this.

I determined two possible fixes:
1. Add a CMakeLists.txt file with the *.cmake file with the line include(<project.name>.cmake) and change lines
at the end of cmake_workspace.lua m.generate()
prjdir = getdirectory(prjpath)
if(prjdir == ".")
then
  p.w("include(%s)", prjpath)
else
  p.w("addsubdirectory(%s)", prjdir)
end

2. Change cmake_project.lua m.files() to make the files relative to workspace directory or current working directory. Since workspace directory is not accessible from here, I changed used the current working directory.

1. Requires the generation of multiple files for the workspace (one additional file per project). This is not supported by premake's api so I chose to implement 2.
