### PR TITLE
Fix linking to system libraries

### DIFF
--- a/cmake_project.lua
+++ b/cmake_project.lua
@@ -118,7 +118,7 @@ function m.generate(prj)
 		  _p(1, '-Wl,--end-group')
 		  _p(1, '-Wl,--start-group')
 		end
-		for _, link in ipairs(config.getlinks(cfg, "system", "basename")) do
+		for _, link in ipairs(config.getlinks(cfg, "system", "fullpath")) do
 			_p(1, '$<$<CONFIG:%s>:%s>', cmake.cfgname(cfg), link)
 		end
 		if uselinkgroups then


### PR DESCRIPTION
Previously, "basename" was used which incorrectly truncates versioned
library names, eg. `glib-2.0` becomes `glib-2`. This change uses
"fullpath" to reflect `premake-core`s `src/tools/gcc.lua` which uses it
inside `gcc.getlinks`.

https://github.com/premake/premake-core/blob/23f32c2759d41ee34f967188d09d5d1d9ece2d7b/src/tools/gcc.lua#L492