### PR TITLE
Fix broken source file paths

### DIFF
--- a/cmake_project.lua
+++ b/cmake_project.lua
@@ -34,7 +34,7 @@ function m.files(prj)
 	local tr = project.getsourcetree(prj)
 	tree.traverse(tr, {
 		onleaf = function(node, depth)
-			_p(depth, '"%s"', path.getrelative(os.getcwd(), node.abspath))
+			_p(depth, '"%s"', path.getrelative(prj.workspace.location, node.abspath))
 		end
 	}, true)
 end


### PR DESCRIPTION
This was broken by PR #3 when the `CMakeLists.txt` was not in the
root/cwd folder

@BinaryAura please check if this doesn't break your project now 😔