### PR TITLE
support cmake executable suffix option

### DIFF
--- a/_preload.lua
+++ b/_preload.lua
@@ -6,11 +6,19 @@
 --              Andrew Gough
 --              Manu Evans
 --              Yehonatan Ballas
+--              UndefinedVertex
 -- Created:     2013/05/06
 -- Copyright:   (c) 2008-2020 Jason Perkins and the Premake project
 --
 
 local p = premake
+
+-- support cmake executable_suffix
+p.api.register {
+	name = "executable_suffix",
+	scope = "config",
+	kind = "string",
+}
 
 newaction
 {

--- a/cmake_project.lua
+++ b/cmake_project.lua
@@ -7,6 +7,7 @@
 --              Tom van Dijck
 --              Yehonatan Ballas
 --              Joel Linn
+--              UndefinedVertex
 -- Created:     2013/05/06
 -- Copyright:   (c) 2008-2020 Jason Perkins and the Premake project
 --
@@ -54,6 +55,9 @@ function m.generate(prj)
 	elseif prj.kind == 'SharedLib' then
 		_p('add_library("%s" SHARED', prj.name)
 	else
+		if prj.executable_suffix then
+			_p('set(CMAKE_EXECUTABLE_SUFFIX "%s")', prj.executable_suffix)
+		end
 		_p('add_executable("%s"', prj.name)
 	end
 	m.files(prj)


### PR DESCRIPTION
cmake executable suffix option support, it can be set in the premake project configuration using

```
executable_suffix (".suffix")
```

use case : needed to compile emscripten project so the suffix had to be .html